### PR TITLE
Get more info on why the install failed

### DIFF
--- a/lib/Command/InstallCommand.php
+++ b/lib/Command/InstallCommand.php
@@ -35,6 +35,11 @@ class InstallCommand extends Command
                 $this->installer->requireExtensions((array) $input->getArgument('extension'));
             } catch (CouldNotInstallExtension $couldNotInstall) {
                 $output->writeln('<error>Could not install</>');
+
+                if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                    throw $couldNotInstall;
+                }
+
                 return 1;
             }
 

--- a/lib/Model/Exception/CouldNotInstallExtension.php
+++ b/lib/Model/Exception/CouldNotInstallExtension.php
@@ -2,8 +2,13 @@
 
 namespace Phpactor\Extension\ExtensionManager\Model\Exception;
 
+use Throwable;
 use RuntimeException;
 
 class CouldNotInstallExtension extends RuntimeException
 {
+    public function __construct(string $message, Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/lib/Service/InstallerService.php
+++ b/lib/Service/InstallerService.php
@@ -83,7 +83,7 @@ class InstallerService
         } catch (Exception $couldNotInstall) {
             $config->revert();
             $this->progress->log('Rolling back configuration');
-            throw new CouldNotInstallExtension($couldNotInstall->getMessage());
+            throw new CouldNotInstallExtension($couldNotInstall->getMessage(), $couldNotInstall);
         }
     }
 }


### PR DESCRIPTION
If you use a `-v` switch on the command, it throws the error instead of just printing a cryptic `Could not install` with a `return 1;`.

I don't thin the verbosity check is needed though, as symfony by itself displays a level of information dependant on the verbosity level.

```php
// ...

function run()
{
    // ...
    try {
        throw new CouldNotInstallExtension('foo');
        // ...
    } catch (CouldNotInstallExtension $couldNotInstall) {
       // ...
       throw $couldNotInstall
    }

    return 0;
}

// ....
```

![image](https://user-images.githubusercontent.com/239685/50730616-c1071200-1151-11e9-88fe-84baa50cbe53.png)

![image](https://user-images.githubusercontent.com/239685/50730607-7d140d00-1151-11e9-9bf2-86038f6c0650.png)

`-v`, `-vv` and `-vvv` gives the same result)